### PR TITLE
Level builder refactoring

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -3,10 +3,10 @@ use bevy::{prelude::*, utils::HashMap};
 use crate::game::{
 	components::CycleTurnability,
 	level::{
-		asset::{plugin as level_asset_plugin, LevelAsset},
+		asset::plugin as level_asset_plugin,
 		list::LevelList,
 		list_asset::{plugin as level_list_asset_plugin, LevelListAsset},
-		GlyphType, ObjectType, ThingType,
+		GlyphType, LevelData, ObjectType, ThingType,
 	},
 };
 
@@ -179,7 +179,7 @@ impl FromWorld for LoadingLevelList {
 #[reflect(Resource)]
 pub struct LoadedLevelList {
 	pub list: LevelList,
-	pub levels: Vec<Handle<LevelAsset>>,
+	pub levels: Vec<Handle<LevelData>>,
 }
 
 impl FromWorld for LoadedLevelList {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -195,7 +195,7 @@ impl FromWorld for LoadedLevelList {
 			levels: level_list
 				.slugs
 				.iter()
-				.map(|slug| asset_server.load(&format!("levels/{slug}.txt")))
+				.map(|slug| asset_server.load(format!("levels/{slug}.txt")))
 				.collect(),
 		}
 	}

--- a/src/game/events.rs
+++ b/src/game/events.rs
@@ -1,4 +1,4 @@
-use super::{components::LinkedCycleDirection, level::asset::LevelAsset};
+use super::{components::LinkedCycleDirection, level::LevelData};
 use bevy::prelude::*;
 
 pub(super) fn plugin(app: &mut App) {
@@ -11,7 +11,7 @@ pub(super) fn plugin(app: &mut App) {
 
 /// Trigger event that spawns the content entities of a level
 #[derive(Event, Debug)]
-pub struct SpawnLevel(pub Handle<LevelAsset>);
+pub struct SpawnLevel(pub Handle<LevelData>);
 
 /// Enumerates directions in which a cycle can turn
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/src/game/level/asset.rs
+++ b/src/game/level/asset.rs
@@ -4,15 +4,7 @@ use super::*;
 
 pub fn plugin(app: &mut App) {
 	app.init_asset_loader::<LevelLoader>();
-	app.init_asset::<LevelAsset>();
-}
-
-#[derive(Asset, Clone, Debug, Reflect)]
-pub struct LevelAsset {
-	pub name: String,
-	pub hint: Option<String>,
-	pub data: ValidLevelData,
-	pub layout: layout::LevelLayout,
+	app.init_asset::<LevelData>();
 }
 
 #[derive(Default)]
@@ -21,9 +13,7 @@ struct LevelLoader;
 #[derive(Debug)]
 pub enum LevelLoadingError {
 	IO(std::io::Error),
-	Validation(LevelDataValidationError),
 	Parsing(parser::LevelParsingError),
-	Layout(layout::LevelLayoutError),
 }
 
 impl From<std::io::Error> for LevelLoadingError {
@@ -32,21 +22,9 @@ impl From<std::io::Error> for LevelLoadingError {
 	}
 }
 
-impl From<LevelDataValidationError> for LevelLoadingError {
-	fn from(value: LevelDataValidationError) -> Self {
-		Self::Validation(value)
-	}
-}
-
 impl From<parser::LevelParsingError> for LevelLoadingError {
 	fn from(value: parser::LevelParsingError) -> Self {
 		Self::Parsing(value)
-	}
-}
-
-impl From<layout::LevelLayoutError> for LevelLoadingError {
-	fn from(value: layout::LevelLayoutError) -> Self {
-		Self::Layout(value)
 	}
 }
 
@@ -57,16 +35,8 @@ impl std::fmt::Display for LevelLoadingError {
 				"Level could not be loaded because of an IO error: {}",
 				e
 			)),
-			LevelLoadingError::Validation(e) => f.write_fmt(format_args!(
-				"Level could not be loaded because it is invalid: {}",
-				e
-			)),
 			LevelLoadingError::Parsing(e) => f.write_fmt(format_args!(
 				"Level could not be loaded because of a parsing error: {}",
-				e
-			)),
-			LevelLoadingError::Layout(e) => f.write_fmt(format_args!(
-				"Level could not be loaded because of an error during layout calculations: {}",
 				e
 			)),
 		}
@@ -76,7 +46,7 @@ impl std::fmt::Display for LevelLoadingError {
 impl std::error::Error for LevelLoadingError {}
 
 impl bevy::asset::AssetLoader for LevelLoader {
-	type Asset = LevelAsset;
+	type Asset = LevelData;
 	type Error = LevelLoadingError;
 	type Settings = ();
 
@@ -90,24 +60,7 @@ impl bevy::asset::AssetLoader for LevelLoader {
 			let mut s = String::new();
 			reader.read_to_string(&mut s).await?;
 			let level_data = parser::parse(&s)?;
-			let validated = ValidLevelData::try_from(level_data.data)?;
-			let layout = {
-				let mut builder = layout::LevelLayoutBuilder::new(&validated);
-				for placement in level_data.layout {
-					builder.add_placement(placement)?;
-				}
-				builder.build()?
-			};
-			Ok(LevelAsset {
-				name: level_data
-					.metadata
-					.get("name")
-					.cloned()
-					.unwrap_or("MISSING_NAME".into()),
-				hint: level_data.metadata.get("hint").cloned(),
-				data: validated,
-				layout,
-			})
+			Ok(level_data)
 		}
 	}
 

--- a/src/game/level/builder.rs
+++ b/src/game/level/builder.rs
@@ -22,7 +22,7 @@ pub struct LevelBuilder {
 }
 
 /// Error data for [`LevelBuilderError::CycleDoesNotContainVertex`]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct CycleDoesNotContainVertexError {
 	/// Index of the cycle whose attempted placement failed
 	placed_cycle: usize,
@@ -36,7 +36,7 @@ pub struct CycleDoesNotContainVertexError {
 }
 
 /// Error data for [`LevelBuilderError::CyclesDoNotIntersect`]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct CyclesDoNotIntersectError {
 	/// Index of the cycle whose attempted placement failed
 	placed_cycle: usize,
@@ -53,7 +53,7 @@ pub struct CyclesDoNotIntersectError {
 }
 
 /// Error data for [`LevelBuilderError::CyclesDoNotIntersectTwice`]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct CyclesDoNotIntersectTwiceError {
 	/// Index of the cycle whose attempted placement failed
 	placed_cycle: usize,
@@ -75,7 +75,7 @@ pub struct CyclesDoNotIntersectTwiceError {
 }
 
 /// Error data for [`LevelBuilderError::TooManyVerticesInCycleIntersection`]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct TooManyVerticesInCycleIntersectionError {
 	/// Index of the cycle whose attempted placement failed
 	placed_cycle: usize,
@@ -87,7 +87,7 @@ pub struct TooManyVerticesInCycleIntersectionError {
 }
 
 /// Error data for [`LevelBuilderError::OverlappedLinkedCycles`]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct OverlappedLinkedCyclesError {
 	/// Index of the cycle where a (possibly transitive) link starts
 	source_cycle: usize,
@@ -97,8 +97,7 @@ pub struct OverlappedLinkedCyclesError {
 	shared_vertex: usize,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum LevelBuilderError {
 	/// [`set_level_name`](LevelBuilder::set_level_name)
 	/// was called more than once

--- a/src/game/level/builder.rs
+++ b/src/game/level/builder.rs
@@ -389,7 +389,7 @@ impl LevelBuilder {
 		if self.cycles[target_cycle].placement.is_some() {
 			return Err(LevelBuilderError::CycleAlreadyPlaced(target_cycle));
 		}
-		if !(radius > 0.0) {
+		if radius.is_nan() || radius <= 0.0 {
 			return Err(LevelBuilderError::CycleRadiusNotPositive(
 				target_cycle,
 				radius,

--- a/src/game/level/builder.rs
+++ b/src/game/level/builder.rs
@@ -25,76 +25,76 @@ pub struct LevelBuilder {
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct CycleDoesNotContainVertexError {
 	/// Index of the cycle whose attempted placement failed
-	placed_cycle: usize,
+	pub placed_cycle: usize,
 	/// Placement that was requested for the cycle
-	requested_placement: CyclePlacement,
+	pub requested_placement: CyclePlacement,
 	/// Index of the vertex with fixed position
 	/// that would not lie on the cycle as placed
-	failing_vertex: usize,
+	pub failing_vertex: usize,
 	/// Position of the failing vertex
-	vertex_position: Vec2,
+	pub vertex_position: Vec2,
 }
 
 /// Error data for [`LevelBuilderError::CyclesDoNotIntersect`]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct CyclesDoNotIntersectError {
 	/// Index of the cycle whose attempted placement failed
-	placed_cycle: usize,
+	pub placed_cycle: usize,
 	/// Placement that was requested for the cycle
-	requested_placement: CyclePlacement,
+	pub requested_placement: CyclePlacement,
 	/// Index of the already-placed cycle that shared a vertex
 	/// with the one being placed
-	existing_cycle: usize,
+	pub existing_cycle: usize,
 	/// Placement of the already-placed cycle
-	existing_placement: CyclePlacement,
+	pub existing_placement: CyclePlacement,
 	/// Index of the vertex that the cycles share
 	/// that could not be placed because the cycles do not intersect
-	failing_vertex: usize,
+	pub failing_vertex: usize,
 }
 
 /// Error data for [`LevelBuilderError::CyclesDoNotIntersectTwice`]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct CyclesDoNotIntersectTwiceError {
 	/// Index of the cycle whose attempted placement failed
-	placed_cycle: usize,
+	pub placed_cycle: usize,
 	/// Placement that was requested for the cycle
-	requested_placement: CyclePlacement,
+	pub requested_placement: CyclePlacement,
 	/// Index of the already-placed cycle that shared
 	/// two vertices with the one being placed
-	existing_cycle: usize,
+	pub existing_cycle: usize,
 	/// Placement of the already-placed cycle
-	existing_placement: CyclePlacement,
+	pub existing_placement: CyclePlacement,
 	/// Index of the vertex that has already been placed at the only
 	/// intersection between the cycles
-	existing_vertex: usize,
+	pub existing_vertex: usize,
 	/// Position of the intersection (and the already-placed vertex)
-	vertex_position: Vec2,
+	pub vertex_position: Vec2,
 	/// Index of the vertex that the cycles share
 	/// that could not be placed because the cycles only intersect once
-	failing_vertex: usize,
+	pub failing_vertex: usize,
 }
 
 /// Error data for [`LevelBuilderError::TooManyVerticesInCycleIntersection`]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct TooManyVerticesInCycleIntersectionError {
 	/// Index of the cycle whose attempted placement failed
-	placed_cycle: usize,
+	pub placed_cycle: usize,
 	/// Index of the already-placed cycle that shared
 	/// several vertices with the one being placed
-	existing_cycle: usize,
+	pub existing_cycle: usize,
 	/// Indices of three of the vertices that are shared by the cycles
-	shared_vertices: [usize; 3],
+	pub shared_vertices: [usize; 3],
 }
 
 /// Error data for [`LevelBuilderError::OverlappedLinkedCycles`]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct OverlappedLinkedCyclesError {
 	/// Index of the cycle where a (possibly transitive) link starts
-	source_cycle: usize,
+	pub source_cycle: usize,
 	/// Index of the cycle where a link ends
-	dest_cycle: usize,
+	pub dest_cycle: usize,
 	/// Index of the vertex shared by the two cycles
-	shared_vertex: usize,
+	pub shared_vertex: usize,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/src/game/level/lex.rs
+++ b/src/game/level/lex.rs
@@ -24,7 +24,7 @@ pub enum RawStatement<'a> {
 	Assignment(RawAssignmentStatement<'a>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LexError {
 	/// A line contains non-ascii characters
 	NonAsciiLine(usize),

--- a/src/game/level/lex.rs
+++ b/src/game/level/lex.rs
@@ -33,7 +33,7 @@ pub enum LexError {
 }
 
 pub fn parse(raw_data: &str) -> impl Iterator<Item = Result<(usize, RawStatement), LexError>> {
-	let assignment_regex = Regex::new(r"^(?<KEY>[a-zA-Z0-9_]+)=(?<VALUE>.+)$")
+	let assignment_regex = Regex::new(r"^(?<KEY>[a-zA-Z0-9_]+)=(?<VALUE>.*)$")
 		.expect("I expected to be able to write a valid regex.");
 	let action_regex = Regex::new(r"^(?<VERB>\w+)(\[(?<MODIFIER>[\w\:]+)\])?(?<VALUES>.+)?$")
 		.expect("I expected to be able to write a valid regex.");

--- a/src/game/level/mod.rs
+++ b/src/game/level/mod.rs
@@ -1,18 +1,72 @@
-use itertools::Itertools;
-
 use super::prelude::*;
 
 pub mod asset;
-pub mod layout;
+mod builder;
 mod lex;
 pub mod list;
 pub mod list_asset;
 pub mod parser;
 
-pub use asset::LevelAsset;
+/// Complete description of a level
+#[derive(Debug, Clone, Reflect, Asset)]
+pub struct LevelData {
+	/// Name of the level
+	pub name: String,
+	/// Hint or comment that relates to the level, if any
+	pub hint: Option<String>,
+	/// Data for all vertices in the level
+	pub vertices: Vec<VertexData>,
+	/// Data for all cycles in the level
+	pub cycles: Vec<CycleData>,
+	/// Data for all cycle links that have been explicitly declared in the level file.
+	/// Will be used for rendering the links
+	pub declared_links: Vec<DeclaredLinkData>,
+}
 
-/// How many colors we can paint objects in
-pub const LOGICAL_COLORS: usize = 6;
+/// Description of a single vertex
+#[derive(Debug, Clone, Copy, Reflect)]
+pub struct VertexData {
+	/// Position of the vertex on the screen
+	pub position: Vec2,
+	/// Object that lies on the vertex, if any
+	pub object: Option<ObjectData>,
+	/// Glyph that lies on the vertex, if any
+	pub glyph: Option<GlyphData>,
+}
+
+/// Description of a single cycle
+#[derive(Debug, Clone, Reflect)]
+pub struct CycleData {
+	///  Placement of the cycle
+	pub placement: CyclePlacement,
+	/// Indices into [`LevelData::vertices`]
+	/// that identify the vertices that lie on the cycle, in clockwise order
+	pub vertex_indices: Vec<usize>,
+	/// When the cycle can be turned
+	pub turnability: CycleTurnability,
+	/// All cycles that have to turn when this cycle is turned, including itself
+	pub link_closure: Vec<(usize, LinkedCycleDirection)>,
+}
+
+/// Description of a declared (and visualized) cycle link
+#[derive(Debug, Clone, Copy, Reflect)]
+pub struct DeclaredLinkData {
+	/// Cycle from which the link goes
+	pub source_cycle: usize,
+	/// Cycle to which the link goes
+	pub dest_cycle: usize,
+	/// Relative turning direction between the linked cycles
+	pub direction: LinkedCycleDirection,
+}
+
+/// Computed placement of a cycle
+#[derive(Clone, Copy, PartialEq, Debug, Reflect)]
+pub struct CyclePlacement {
+	/// Position of the center point of the cycle
+	pub position: Vec2,
+	/// Radius of the cycle
+	pub radius: f32,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 pub enum ObjectType {
@@ -45,311 +99,12 @@ pub enum ThingType {
 	Glyph(GlyphType),
 }
 
-#[derive(Debug, Clone, Reflect)]
-pub struct CycleData {
-	pub vertex_indices: Vec<usize>,
-	pub cycle_turnability: CycleTurnability,
-}
-
-#[derive(Debug, Clone, Copy, Reflect)]
-pub struct LinkageData {
-	pub cycle_a_index: usize,
-	pub cycle_b_index: usize,
-	pub direction: LinkedCycleDirection,
-}
-
-#[derive(Debug, Clone, Copy, Default, Reflect)]
-pub struct VertexData {
-	pub object: Option<ObjectData>,
-	pub glyph: Option<GlyphData>,
-}
-
-#[derive(Debug, Clone, Reflect)]
-pub struct LevelData {
-	pub vertices: Vec<VertexData>,
-	pub cycles: Vec<CycleData>,
-	pub linkages: Vec<LinkageData>,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy)]
-pub enum LevelDataValidationError {
-	VertexIndexOutOfRange(usize),
-	CycleIndexOutOfRange(usize),
-	CycleLinkageConflict,
-	TooFewVerticesInCycle(usize),
-	RepeatingVertexInCycle(usize),
-	TooManyVerticesInCycleIntersection(usize, usize),
-	OverlappedLinkedCycles(usize, usize),
-	ColorOutOfRange(usize),
-}
-
-/// A sanitized [`LevelData`] instance.
-/// It is read-only to ensure that it truly remains valid
-#[derive(Debug, Clone, Reflect)]
-pub struct ValidLevelData {
-	/// The contained level data. Guaranteed to be sanitized
-	inner: LevelData,
-	/// Computed equivalence closure of links between cycles.
-	/// The sanitizer needs to compute this anyway, so it is
-	/// included here for convenience
-	links: Vec<Vec<Option<LinkedCycleDirection>>>,
-}
-
-impl ValidLevelData {
-	/// Iterates over indices of cycles that are, directly or indirectly,
-	/// linked to a given cycle. The original cycle is not included in the result.
-	pub fn cycles_linked_to(
-		&self,
-		index: usize,
-	) -> impl Iterator<Item = (usize, LinkedCycleDirection)> + '_ {
-		self.links[index]
-			.iter()
-			.enumerate()
-			.filter_map(|(i, x)| x.map(|x| (i, x)))
-			.filter(move |(i, _)| *i != index)
-	}
-}
-
-impl TryFrom<LevelData> for ValidLevelData {
-	type Error = LevelDataValidationError;
-
-	fn try_from(value: LevelData) -> Result<Self, Self::Error> {
-		// Object color range
-		for vertex in &value.vertices {
-			if let Some(object) = vertex.object {
-				if let Some(color) = object.color {
-					if color.0 >= LOGICAL_COLORS {
-						return Err(LevelDataValidationError::ColorOutOfRange(color.0));
-					}
-				}
-			}
-			if let Some(glyph) = vertex.glyph {
-				if let Some(color) = glyph.color {
-					if color.0 >= LOGICAL_COLORS {
-						return Err(LevelDataValidationError::ColorOutOfRange(color.0));
-					}
-				}
-			}
-		}
-
-		// Everything about integrity of individual cycles
-		for (i, cycle) in value.cycles.iter().enumerate() {
-			if cycle.vertex_indices.len() < 2 {
-				return Err(LevelDataValidationError::TooFewVerticesInCycle(i));
-			}
-			if !cycle.vertex_indices.iter().all_unique() {
-				return Err(LevelDataValidationError::RepeatingVertexInCycle(i));
-			}
-			if let Some(j) = cycle
-				.vertex_indices
-				.iter()
-				.copied()
-				.find(|&j| j >= value.vertices.len())
-			{
-				return Err(LevelDataValidationError::VertexIndexOutOfRange(j));
-			}
-		}
-
-		// A very, *very* inefficient way of finding conflicts between cycle links
-		// Only reasonably fast (and space-efficient) for 20 cycles or so
-		let mut cycle_links = (0..value.cycles.len())
-			.map(|i| {
-				(0..value.cycles.len())
-					.map(|j| {
-						if i == j {
-							Some(LinkedCycleDirection::Coincident)
-						} else {
-							None
-						}
-					})
-					.collect::<Vec<_>>()
-			})
-			.collect::<Vec<_>>();
-		fn set_link(
-			links: &mut [Vec<Option<LinkedCycleDirection>>],
-			i: usize,
-			j: usize,
-			dir: LinkedCycleDirection,
-		) -> Result<(), LevelDataValidationError> {
-			if links[i][j].is_some_and(|d| d != dir) {
-				return Err(LevelDataValidationError::CycleLinkageConflict);
-			}
-			links[i][j] = Some(dir);
-			links[j][i] = Some(dir);
-			Ok(())
-		}
-		for link in &value.linkages {
-			let i = link.cycle_a_index;
-			let j = link.cycle_b_index;
-			if i >= value.cycles.len() {
-				return Err(LevelDataValidationError::CycleIndexOutOfRange(i));
-			}
-			if j >= value.cycles.len() {
-				return Err(LevelDataValidationError::CycleIndexOutOfRange(j));
-			}
-			for k in 0..value.cycles.len() {
-				if let Some(old_link) = cycle_links[i][k] {
-					set_link(&mut cycle_links, j, k, link.direction * old_link)?;
-				}
-				if let Some(old_link) = cycle_links[j][k] {
-					set_link(&mut cycle_links, i, k, link.direction * old_link)?;
-				}
-			}
-		}
-
-		// Everything about overlapping cycles
-		let vertices_per_cycle = value
-			.cycles
-			.iter()
-			.map(|c| std::collections::BTreeSet::from_iter(c.vertex_indices.iter().copied()))
-			.collect::<Vec<_>>();
-		for ((i, a), (j, b)) in vertices_per_cycle.iter().enumerate().tuple_combinations() {
-			let common_vertices = a.intersection(b).count();
-			if common_vertices > 2 {
-				return Err(LevelDataValidationError::TooManyVerticesInCycleIntersection(i, j));
-			}
-			if common_vertices > 0 && cycle_links[i][j].is_some() {
-				return Err(LevelDataValidationError::OverlappedLinkedCycles(i, j));
-			}
-		}
-
-		Ok(Self {
-			inner: value,
-			links: cycle_links,
-		})
-	}
-}
-
-impl std::ops::Deref for ValidLevelData {
-	type Target = LevelData;
-	fn deref(&self) -> &Self::Target {
-		&self.inner
-	}
-}
-
-impl std::borrow::Borrow<LevelData> for ValidLevelData {
-	fn borrow(&self) -> &LevelData {
-		&self.inner
-	}
-}
-
-impl std::fmt::Display for LevelDataValidationError {
+impl std::fmt::Display for CyclePlacement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			Self::VertexIndexOutOfRange(i) => write!(
-				f,
-				"Vertex index {i} is used, but there are not that many vertices."
-			),
-			Self::CycleIndexOutOfRange(i) => write!(
-				f,
-				"Cycle index {i} is used, but there are not that many cycles."
-			),
-			Self::CycleLinkageConflict => write!(f, "Contradictory cycle links."),
-			Self::TooFewVerticesInCycle(i) => {
-				write!(f, "Cycle {i} contains less than two vertices.")
-			}
-			Self::RepeatingVertexInCycle(i) => {
-				write!(f, "Cycle {i} contains the same vertex multiple times.")
-			}
-			Self::TooManyVerticesInCycleIntersection(i, j) => {
-				write!(f, "Cycles {i} and {j} intersect in more than two vertices.")
-			}
-			Self::OverlappedLinkedCycles(i, j) => {
-				write!(f, "Cycles {i} and {j} are overlapped and linked.")
-			}
-			Self::ColorOutOfRange(c) => {
-				write!(
-					f,
-					"Color {c} is used, but there are only {LOGICAL_COLORS} colors."
-				)
-			}
-		}
-	}
-}
-
-impl std::error::Error for LevelDataValidationError {}
-
-#[cfg(test)]
-mod test {
-	use super::*;
-	use LinkedCycleDirection::*;
-
-	macro_rules! level_data {
-		($vertices:expr, [$([$($cycles:expr),* $(,)?]),* $(,)?], [$(($a:expr, $b:expr, $dir:expr)),* $(,)?]) => {
-			ValidLevelData::try_from(LevelData {
-				vertices: vec![VertexData::default(); $vertices],
-				cycles: vec![$(CycleData { vertex_indices: vec![$($cycles),*], cycle_turnability: CycleTurnability::Always }),*],
-				linkages: vec![$(LinkageData { cycle_a_index: $a, cycle_b_index: $b, direction: $dir }),*]
-			})
-		};
-	}
-
-	#[test]
-	fn test_validation() {
-		assert!(level_data!(4, [[0, 1], [2, 3]], []).is_ok());
-		assert!(level_data!(6, [[0, 1, 2], [2, 3, 4, 5]], []).is_ok());
-		assert!(level_data!(6, [[0, 1, 2, 4], [2, 3, 4, 5]], []).is_ok());
-		assert!(level_data!(4, [[0, 1], [2, 3]], [(0, 0, Coincident)]).is_ok());
-		assert!(level_data!(4, [[0, 1], [2, 3]], [(0, 1, Coincident)]).is_ok());
-		assert!(level_data!(
-			4,
-			[[0, 1], [2, 3]],
-			[(0, 1, Coincident), (1, 0, Coincident)]
+		write!(
+			f,
+			"[x={} y={} r={}]",
+			self.position.x, self.position.y, self.radius
 		)
-		.is_ok());
-		assert!(level_data!(
-			6,
-			[[0, 1], [2, 3], [4, 5]],
-			[(0, 1, Coincident), (1, 2, Inverse)]
-		)
-		.is_ok());
-		assert!(level_data!(
-			6,
-			[[0, 1], [2, 3], [4, 5]],
-			[(0, 1, Coincident), (1, 2, Inverse), (0, 2, Inverse)]
-		)
-		.is_ok());
-		assert!(level_data!(
-			6,
-			[[0, 1], [2, 3], [4, 5]],
-			[(0, 1, Coincident), (1, 2, Coincident), (0, 2, Coincident)]
-		)
-		.is_ok());
-		assert!(level_data!(5, [[0, 1], [2, 3], [4, 2]], [(0, 1, Coincident)]).is_ok());
-
-		assert!(level_data!(6, [[0, 1, 2, 4], [0, 2, 3, 4, 5]], []).is_err());
-		assert!(level_data!(4, [[0, 1], [2, 3]], [(0, 0, Inverse)]).is_err());
-		assert!(level_data!(3, [[0, 1], [1, 2]], [(0, 1, Coincident)]).is_err());
-		assert!(level_data!(4, [[0, 1], [2, 3]], [(0, 1, Coincident), (1, 0, Inverse)]).is_err());
-		assert!(level_data!(
-			6,
-			[[0, 1], [2, 3], [4, 5]],
-			[(0, 1, Coincident), (1, 2, Inverse), (0, 2, Coincident)]
-		)
-		.is_err());
-		assert!(level_data!(
-			6,
-			[[0, 1], [2, 3], [4, 5]],
-			[(0, 1, Inverse), (1, 2, Coincident), (0, 2, Coincident)]
-		)
-		.is_err());
-		assert!(level_data!(
-			8,
-			[[0, 1], [2, 3], [4, 5], [6, 7]],
-			[
-				(0, 1, Coincident),
-				(1, 2, Coincident),
-				(2, 3, Coincident),
-				(3, 1, Inverse)
-			]
-		)
-		.is_err());
-		assert!(level_data!(
-			5,
-			[[0, 1], [2, 3], [4, 2]],
-			[(0, 1, Coincident), (0, 2, Coincident)]
-		)
-		.is_err());
 	}
 }

--- a/src/game/level/parser.rs
+++ b/src/game/level/parser.rs
@@ -1,315 +1,196 @@
-use super::*;
-
-use super::lex::*;
+use super::{builder::*, lex::*, *};
 use bevy::utils::hashbrown::HashMap;
-use layout::{CyclePlacement, DeclaredCyclePlacement, DeclaredPlacement, DeclaredVertexPlacement};
+use itertools::Itertools as _;
 
-#[derive(Clone, Debug)]
-pub struct LevelFile {
-	pub metadata: HashMap<String, String>,
-	pub data: LevelData,
-	pub layout: Vec<layout::DeclaredPlacement>,
-}
-
-enum Statement<'a> {
-	Vertex(Vec<&'a str>),
-	Cycle(CycleTurnability, Vec<&'a str>),
-	Link(LinkedCycleDirection, Vec<&'a str>),
-	Object(ObjectKind, Option<LogicalColor>, Vec<&'a str>),
-	Place(Vec<&'a str>),
-	PlaceVertex(Vec<&'a str>),
-}
-
-enum ObjectKind {
-	Object(ObjectType),
-	Glyph(GlyphType),
-}
-
-pub fn parse(level_file: &str) -> Result<LevelFile, LevelParsingError> {
-	let mut raw_statements: Vec<(usize, RawActionStatement)> = Vec::new();
-	let mut metadata = HashMap::new();
+pub fn parse(level_file: &str) -> Result<LevelData, LevelParsingError> {
+	let mut builder = LevelBuilder::new();
+	let mut vertex_names = HashMap::new();
+	let mut cycle_names = HashMap::new();
 
 	for line in lex::parse(level_file) {
 		let (line_id, statement) = line?;
 		match statement {
 			RawStatement::Assignment(statement) => {
-				let key = statement.key.to_ascii_lowercase();
-				let value = statement.value.to_owned();
-				metadata.insert(key, value); // TODO: check for duplicate keywords
+				match statement.key.to_ascii_lowercase().as_str() {
+					"name" => builder.set_level_name(statement.value.to_owned())?,
+					"hint" => builder.set_level_hint(statement.value.to_owned())?,
+					other => return Err(LevelParsingError::InvalidMetaVariable(other.to_owned())),
+				}
 			}
 			RawStatement::Action(statement) => {
-				raw_statements.push((line_id, statement));
-			}
-		}
-	}
-
-	let mut statements = Vec::new();
-
-	for (line_id, raw_statement) in raw_statements {
-		statements.push((
-			line_id,
-			match raw_statement.verb {
-				"VERTEX" => Statement::Vertex(raw_statement.values),
-				"CYCLE" => {
-					let turnability = match raw_statement.modifier {
-						None => CycleTurnability::Always,
-						Some("MANUAL") => CycleTurnability::WithPlayer,
-						Some("ENGINE") => CycleTurnability::Always,
-						Some("STILL") => CycleTurnability::Never,
-						Some(m) => return Err(LevelParsingError::InvalidModifier(m.to_string())),
-					};
-					Statement::Cycle(turnability, raw_statement.values)
-				}
-				"LINK" => {
-					let flip = match raw_statement.modifier {
-						None => LinkedCycleDirection::Coincident,
-						Some("STRAIGHT") => LinkedCycleDirection::Coincident,
-						Some("CROSSED") => LinkedCycleDirection::Inverse,
-						Some(m) => return Err(LevelParsingError::InvalidModifier(m.to_string())),
-					};
-					Statement::Link(flip, raw_statement.values)
-				}
-				"OBJECT" => {
-					let Some(modifier) = raw_statement.modifier else {
-						return Err(LevelParsingError::MalformedStatement(line_id));
-					};
-					let (object_kind, color) = modifier.split_once(':').unwrap_or((modifier, ""));
-					let kind = match object_kind {
-						"BOX" => ObjectKind::Object(ObjectType::Box),
-						"PLAYER" => ObjectKind::Object(ObjectType::Player),
-						"BUTTON" => ObjectKind::Glyph(GlyphType::Button),
-						"FLAG" => ObjectKind::Glyph(GlyphType::Flag),
-						_ => return Err(LevelParsingError::InvalidModifier(modifier.to_string())),
-					};
-					let color_id = if color.is_empty() {
-						None
-					} else if let Ok(color_id) = color.parse() {
-						Some(LogicalColor(color_id))
-					} else {
-						return Err(LevelParsingError::InvalidModifier(modifier.to_string()));
-					};
-					Statement::Object(kind, color_id, raw_statement.values)
-				}
-				"PLACE" => Statement::Place(raw_statement.values),
-				"PLACE_VERT" => Statement::PlaceVertex(raw_statement.values),
-				k => return Err(LevelParsingError::InvalidKeyword(k.to_string())), // TODO: line number
-			},
-		));
-	}
-
-	let mut vertices = Vec::new();
-	let mut vertex_names = HashMap::new();
-
-	for (_, statement) in statements.iter() {
-		if let Statement::Vertex(names) = statement {
-			if names.is_empty() {
-				// TODO: warn
-			}
-			for name in names {
-				if vertex_names.contains_key(*name) {
-					// TODO: warn
-				} else {
-					let new_id = vertices.len();
-					vertices.push(VertexData {
-						object: None,
-						glyph: None,
-					});
-					vertex_names.insert(name.to_string(), new_id);
-				}
-			}
-		}
-	}
-
-	let mut cycles = Vec::new();
-	let mut cycle_names = HashMap::new();
-
-	for (line_id, statement) in statements.iter() {
-		if let Statement::Cycle(turnability, names) = statement {
-			if vertex_names.len() < 3 {
-				// TODO: better error
-				return Err(LevelParsingError::MalformedStatement(*line_id));
-			}
-			let cycle_name = *names.first().unwrap();
-			if cycle_names.contains_key(cycle_name) {
-				return Err(LevelParsingError::RedefinedCycle(cycle_name.to_string()));
-			}
-			let mut cycle = CycleData {
-				vertex_indices: Vec::new(),
-				cycle_turnability: *turnability,
-			};
-			for vertex_name in names.iter().skip(1) {
-				if let Some(vertex_id) = vertex_names.get(*vertex_name) {
-					cycle.vertex_indices.push(*vertex_id);
-				} else {
-					return Err(LevelParsingError::UnknownVertexName(
-						vertex_name.to_string(),
-					));
-				}
-			}
-			let new_id = cycles.len();
-			cycles.push(cycle);
-			cycle_names.insert(cycle_name.to_string(), new_id);
-		}
-	}
-
-	let mut linkages: Vec<LinkageData> = Vec::new();
-
-	for (line_id, statement) in statements.iter() {
-		if let Statement::Link(flip, linked_cycle_names) = statement {
-			if linked_cycle_names.len() < 2 {
-				// TODO: better error
-				return Err(LevelParsingError::MalformedStatement(*line_id));
-			}
-			let mut last_cycle = None;
-			for cycle_name in linked_cycle_names {
-				if let Some(cycle_id) = cycle_names.get(*cycle_name) {
-					if let Some(previous_cycle_id) = last_cycle {
-						linkages.push(LinkageData {
-							cycle_a_index: previous_cycle_id,
-							cycle_b_index: *cycle_id,
-							direction: *flip,
-						});
-					}
-					last_cycle = Some(*cycle_id);
-				} else {
-					return Err(LevelParsingError::UnknownCycleName(cycle_name.to_string()));
-				}
-			}
-		}
-	}
-
-	for (_, statement) in statements.iter() {
-		if let Statement::Object(kind, color, placed_vertex_names) = statement {
-			if placed_vertex_names.is_empty() {
-				// TODO: warn
-			}
-			for name in placed_vertex_names {
-				if let Some(vertex_id) = vertex_names.get(*name) {
-					let vertex = vertices.get_mut(*vertex_id).unwrap();
-					match kind {
-						ObjectKind::Object(object) => {
-							if vertex.object.is_some() {
-								return Err(LevelParsingError::ObjectCollision(name.to_string()));
-							}
-							vertex.object = Some(ObjectData {
-								object_type: *object,
-								color: *color,
-							});
-						}
-						ObjectKind::Glyph(glyph) => {
-							if vertex.glyph.is_some() {
-								return Err(LevelParsingError::ObjectCollision(name.to_string()));
-							}
-							vertex.glyph = Some(GlyphData {
-								glyph_type: *glyph,
-								color: *color,
-							});
+				match statement.verb {
+					"VERTEX" => {
+						for name in statement.values {
+							let vertex = builder.add_vertex()?;
+							vertex_names.insert(name.to_owned(), vertex);
 						}
 					}
-				} else {
-					return Err(LevelParsingError::UnknownVertexName(name.to_string()));
+					"CYCLE" => {
+						let turnability = match statement.modifier {
+							None => CycleTurnability::Always,
+							Some("MANUAL") => CycleTurnability::WithPlayer,
+							Some("ENGINE") => CycleTurnability::Always,
+							Some("STILL") => CycleTurnability::Never,
+							Some(m) => {
+								return Err(LevelParsingError::InvalidModifier(m.to_string()))
+							}
+						};
+						let mut values = statement.values.into_iter();
+						let name = values
+							.next()
+							.ok_or(LevelParsingError::NotEnoughArguments(1, 0))?;
+						let vertices = values
+							.map(|name| {
+								vertex_names.get(name).copied().ok_or_else(|| {
+									LevelParsingError::UnknownVertexName(name.to_owned())
+								})
+							})
+							.collect::<Result<Vec<_>, _>>()?;
+						let cycle = builder.add_cycle(turnability, vertices)?;
+						cycle_names.insert(name.to_owned(), cycle);
+					}
+					"LINK" => {
+						let direction = match statement.modifier {
+							None => LinkedCycleDirection::Coincident,
+							Some("STRAIGHT") => LinkedCycleDirection::Coincident,
+							Some("CROSSED") => LinkedCycleDirection::Inverse,
+							Some(m) => {
+								return Err(LevelParsingError::InvalidModifier(m.to_string()))
+							}
+						};
+						let cycles = statement
+							.values
+							.into_iter()
+							.map(|name| {
+								cycle_names.get(name).copied().ok_or_else(|| {
+									LevelParsingError::UnknownVertexName(name.to_owned())
+								})
+							})
+							.collect::<Result<Vec<_>, _>>()?;
+						if cycles.len() < 2 {
+							return Err(LevelParsingError::NotEnoughArguments(2, cycles.len()));
+						}
+						for (source, dest) in cycles.into_iter().tuple_windows() {
+							builder.link_cycles(source, dest, direction)?;
+						}
+					}
+					"OBJECT" => {
+						let Some(modifier) = statement.modifier else {
+							return Err(LevelParsingError::MalformedStatement(line_id));
+						};
+						let (object_kind, color) =
+							modifier.split_once(':').unwrap_or((modifier, ""));
+						let _color_id = if color.is_empty() {
+							None
+						} else if let Ok(color_id) = color.parse() {
+							Some(LogicalColor(color_id))
+						} else {
+							return Err(LevelParsingError::InvalidModifier(modifier.to_string()));
+						};
+						let thing_type = match object_kind {
+							"BOX" => ThingType::Object(ObjectType::Box),
+							"PLAYER" => ThingType::Object(ObjectType::Player),
+							"BUTTON" => ThingType::Glyph(GlyphType::Button),
+							"FLAG" => ThingType::Glyph(GlyphType::Flag),
+							_ => {
+								return Err(LevelParsingError::InvalidModifier(
+									modifier.to_string(),
+								))
+							}
+						};
+						for vertex_name in statement.values {
+							let Some(vertex) = vertex_names.get(vertex_name).copied() else {
+								return Err(LevelParsingError::UnknownVertexName(
+									vertex_name.to_owned(),
+								));
+							};
+							// TODO: Bring back colors
+							match thing_type {
+								ThingType::Object(object_type) => builder.add_object(
+									vertex,
+									ObjectData {
+										object_type,
+										color: None,
+									},
+								)?,
+								ThingType::Glyph(glyph_type) => builder.add_glyph(
+									vertex,
+									GlyphData {
+										glyph_type,
+										color: None,
+									},
+								)?,
+							}
+						}
+					}
+					"PLACE" => {
+						if statement.values.len() < 4 {
+							return Err(LevelParsingError::NotEnoughArguments(
+								4,
+								statement.values.len(),
+							));
+						}
+						let cycle_name = statement.values[0];
+						let x_str = statement.values[1].replace(',', ".");
+						let y_str = statement.values[2].replace(',', ".");
+						let r_str = statement.values[3].replace(',', ".");
+						let Some(cycle_id) = cycle_names.get(cycle_name).copied() else {
+							return Err(LevelParsingError::UnknownCycleName(
+								cycle_name.to_string(),
+							));
+						};
+						let Ok(x) = x_str.parse::<f32>() else {
+							return Err(LevelParsingError::MalformedStatement(line_id));
+						};
+						let Ok(y) = y_str.parse::<f32>() else {
+							return Err(LevelParsingError::MalformedStatement(line_id));
+						};
+						let Ok(r) = r_str.parse::<f32>() else {
+							return Err(LevelParsingError::MalformedStatement(line_id));
+						};
+						let hints = statement.values[4..]
+							.iter()
+							.map(|name| {
+								vertex_names
+									.get(*name)
+									.copied()
+									.ok_or(LevelParsingError::UnknownVertexName(name.to_string()))
+							})
+							.collect::<Result<Vec<_>, _>>()?;
+						builder.place_cycle(cycle_id, Vec2::new(x, y), r, &hints)?;
+					}
+					"PLACE_VERT" => {
+						if statement.values.len() < 2 {
+							return Err(LevelParsingError::NotEnoughArguments(
+								2,
+								statement.values.len(),
+							));
+						}
+						let vertex_name = statement.values[0];
+						let angle_str = statement.values[1].replace(',', ".");
+						let Some(vertex_id) = vertex_names.get(vertex_name).copied() else {
+							return Err(LevelParsingError::UnknownCycleName(
+								vertex_name.to_string(),
+							));
+						};
+						let Ok(angle) = angle_str.parse::<f32>() else {
+							return Err(LevelParsingError::MalformedStatement(line_id));
+						};
+						builder.place_vertex(vertex_id, angle)?;
+					}
+					other => return Err(LevelParsingError::InvalidKeyword(other.to_owned())),
 				}
 			}
 		}
 	}
 
-	let mut cycle_layout: Vec<Option<(CyclePlacement, Vec<usize>)>> =
-		(0..cycles.len()).map(|_| None).collect();
-
-	for (line_id, statement) in statements.iter() {
-		if let Statement::Place(data) = statement {
-			if data.len() < 4 {
-				return Err(LevelParsingError::MalformedStatement(*line_id));
-			}
-			let cycle_name = data[0];
-			let x_str = data[1].replace(',', ".");
-			let y_str = data[2].replace(',', ".");
-			let r_str = data[3].replace(',', ".");
-			let Some(cycle_id) = cycle_names.get(cycle_name) else {
-				return Err(LevelParsingError::UnknownCycleName(cycle_name.to_string()));
-			};
-			let Ok(x) = x_str.parse::<f32>() else {
-				return Err(LevelParsingError::MalformedStatement(*line_id));
-			};
-			let Ok(y) = y_str.parse::<f32>() else {
-				return Err(LevelParsingError::MalformedStatement(*line_id));
-			};
-			let Ok(r) = r_str.parse::<f32>() else {
-				return Err(LevelParsingError::MalformedStatement(*line_id));
-			};
-			let hints = data[4..]
-				.iter()
-				.map(|name| {
-					vertex_names
-						.get(*name)
-						.copied()
-						.ok_or(LevelParsingError::UnknownVertexName(name.to_string()))
-				})
-				.collect::<Result<_, _>>()?;
-			cycle_layout[*cycle_id] = Some((
-				CyclePlacement {
-					position: Vec2::new(x, y),
-					radius: r,
-				},
-				hints,
-			));
-		}
-	}
-
-	if !cycle_layout.iter().all(Option::is_some) {
-		return Err(LevelParsingError::MissingCycleLayout);
-	}
-
-	let mut layout: Vec<DeclaredPlacement> = cycle_layout
-		.into_iter()
-		.enumerate()
-		.map(|(i, x)| {
-			let (placement, hints) = x.unwrap();
-			DeclaredPlacement::Cycle(DeclaredCyclePlacement {
-				cycle_index: i,
-				position: placement.position,
-				radius: placement.radius,
-				double_intersection_hints: hints,
-			})
-		})
-		.collect();
-
-	for (line_id, statement) in statements.iter() {
-		if let Statement::PlaceVertex(data) = statement {
-			if data.len() < 2 {
-				return Err(LevelParsingError::MalformedStatement(*line_id));
-			}
-			let vertex_name = data[0];
-			let angle_str = data[1].replace(',', ".");
-			if let Some(vertex_id) = vertex_names.get(vertex_name) {
-				let Ok(angle) = angle_str.parse::<f32>() else {
-					return Err(LevelParsingError::MalformedStatement(*line_id));
-				};
-				layout.push(DeclaredPlacement::Vertex(DeclaredVertexPlacement {
-					vertex_index: *vertex_id,
-					relative_angle: angle,
-				}))
-			} else {
-				return Err(LevelParsingError::UnknownCycleName(vertex_name.to_string()));
-			}
-		}
-	}
-
-	Ok(LevelFile {
-		metadata,
-		data: LevelData {
-			vertices,
-			cycles,
-			linkages,
-		},
-		layout,
-	})
+	Ok(builder.build()?)
 }
 
 #[test]
 fn basic_test() {
 	let data = r"
-TEST6=?!#_AAA 648
+NAME=?!#_AAA 648
 HINT=This should parse correctly!
 
 # Here we declare all the vertex names
@@ -362,11 +243,20 @@ pub enum LevelParsingError {
 	LexError(LexError),
 	MalformedStatement(usize),
 	MissingCycleLayout,
+	InvalidMetaVariable(String),
+	BuilderError(LevelBuilderError),
+	NotEnoughArguments(usize, usize),
 }
 
 impl From<LexError> for LevelParsingError {
 	fn from(value: LexError) -> Self {
 		Self::LexError(value)
+	}
+}
+
+impl From<LevelBuilderError> for LevelParsingError {
+	fn from(value: LevelBuilderError) -> Self {
+		Self::BuilderError(value)
 	}
 }
 
@@ -402,6 +292,14 @@ impl std::fmt::Display for LevelParsingError {
 			LevelParsingError::MissingCycleLayout => {
 				write!(f, "Some cycles don't have a position specified")?
 			}
+			LevelParsingError::InvalidMetaVariable(name) => {
+				write!(f, "{name} is not a valid meta variable name")?
+			}
+			LevelParsingError::BuilderError(e) => e.fmt(f)?,
+			LevelParsingError::NotEnoughArguments(needed, got) => write!(
+				f,
+				"Statement found {got} arguments, needs at least {needed}."
+			)?,
 		}
 		Ok(())
 	}

--- a/src/game/level/parser.rs
+++ b/src/game/level/parser.rs
@@ -231,7 +231,7 @@ PLACE cycle_extra -100 100 50
 	println!("{:?}", parsed.unwrap());
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum LevelParsingError {
 	InvalidKeyword(String),
 	InvalidModifier(String),

--- a/src/game/logic.rs
+++ b/src/game/logic.rs
@@ -29,17 +29,14 @@ fn cycle_group_rotation_relay_system(
 		// We assume that the RotateCycleGroup event always targets a valid target and a rotation happens.
 		update_event.send(GameLayoutChanged);
 		single_events.send_batch(
-			std::iter::once(group_rotation.0)
-				.chain(
-					cycles_q
-						.get(group_rotation.0.target_cycle)
-						.into_iter()
-						.flat_map(|links| &links.0)
-						.map(|&(id, relative_direction)| RotateCycle {
-							target_cycle: id,
-							direction: group_rotation.0.direction * relative_direction,
-						}),
-				)
+			cycles_q
+				.get(group_rotation.0.target_cycle)
+				.into_iter()
+				.flat_map(|links| &links.0)
+				.map(|&(id, relative_direction)| RotateCycle {
+					target_cycle: id,
+					direction: group_rotation.0.direction * relative_direction,
+				})
 				.map(RotateSingleCycle),
 		);
 	}

--- a/src/game/resources.rs
+++ b/src/game/resources.rs
@@ -1,6 +1,6 @@
 use bevy::color::palettes;
 
-use super::{level::LOGICAL_COLORS, prelude::*};
+use super::prelude::*;
 
 pub(super) fn plugin(app: &mut App) {
 	app.init_resource::<LevelCompletionConditions>()
@@ -75,6 +75,9 @@ impl FromWorld for LinkMaterial {
 		}))
 	}
 }
+
+// TODO: Delete this when we remove color-coding from logical colors
+const LOGICAL_COLORS: usize = 6;
 
 /// Contains colors used for rendering objects and glyphs
 #[derive(Resource, Debug, Clone, Reflect)]

--- a/src/game/spawn/level.rs
+++ b/src/game/spawn/level.rs
@@ -13,7 +13,6 @@ use bevy::math::{
 	primitives,
 };
 use bevy::sprite::Anchor::Custom;
-use itertools::Itertools;
 use rand::Rng;
 
 pub(super) fn plugin(app: &mut App) {
@@ -25,7 +24,7 @@ fn spawn_level(
 	mut events: EventWriter<GameLayoutChanged>,
 	mut commands: Commands,
 	mut meshes: ResMut<Assets<Mesh>>,
-	levels: Res<Assets<LevelAsset>>,
+	levels: Res<Assets<LevelData>>,
 	mut is_level_completed: ResMut<IsLevelCompleted>,
 	mut move_history: ResMut<MoveHistory>,
 	cycle_material: ResMut<RingMaterial>,
@@ -39,22 +38,14 @@ fn spawn_level(
 	let level = levels
 		.get(level)
 		.expect("Got an invalid handle to a level asset");
-	let data = &level.data;
-	let layout = &{
-		let mut layout = level.layout.clone();
-		layout.recompute_to_fit(LEVEL_AREA_WIDTH / 2.0, LEVEL_AREA_CENTER);
-		layout
-	};
 
-	let vertices: Vec<Entity> = data
+	let vertices: Vec<Entity> = level
 		.vertices
 		.iter()
-		.zip_eq(&layout.vertices)
-		.map(|(data, pos)| {
+		.map(|data| {
 			spawn_vertex(
 				commands.reborrow(),
 				data,
-				*pos,
 				meshes.reborrow(),
 				cycle_material.0.clone(),
 				palette.as_ref(),
@@ -63,11 +54,10 @@ fn spawn_level(
 		})
 		.collect();
 
-	let cycle_ids = data
+	let cycle_ids = level
 		.cycles
 		.iter()
-		.zip_eq(&layout.cycles)
-		.map(|(data, pos)| {
+		.map(|data| {
 			spawn_cycle(
 				commands.reborrow(),
 				meshes.reborrow(),
@@ -75,16 +65,16 @@ fn spawn_level(
 				&palette,
 				&image_handles,
 				data,
-				*pos,
 				&vertices,
 			)
 		})
 		.collect::<Vec<_>>();
 
 	for (i, cycle_id) in cycle_ids.iter().copied().enumerate() {
-		let linked_cycles = data
-			.cycles_linked_to(i)
-			.map(|(j, dir)| (cycle_ids[j], dir))
+		let linked_cycles = level.cycles[i]
+			.link_closure
+			.iter()
+			.map(|&(j, dir)| (cycle_ids[j], dir))
 			.collect::<Vec<_>>();
 		if !linked_cycles.is_empty() {
 			commands
@@ -93,9 +83,9 @@ fn spawn_level(
 		}
 	}
 
-	for link in &data.linkages {
-		let a = layout.cycles[link.cycle_a_index].position;
-		let b = layout.cycles[link.cycle_b_index].position;
+	for link in &level.declared_links {
+		let a = level.cycles[link.source_cycle].placement.position;
+		let b = level.cycles[link.dest_cycle].placement.position;
 		let d_sq = a.distance_squared(b);
 		if d_sq <= CYCLE_LINK_SPACING.powi(2) {
 			// The link cannot be rendered if the cycles are too close
@@ -160,14 +150,13 @@ fn spawn_level(
 fn spawn_vertex(
 	mut commands: Commands,
 	data: &VertexData,
-	position: Vec2,
 	mut meshes: Mut<Assets<Mesh>>,
 	base_material: Handle<ColorMaterial>,
 	palette: &ThingPalette,
 	image_handles: &HandleMap<ImageKey>,
 ) -> Entity {
 	let transform =
-		TransformBundle::from_transform(Transform::from_translation(position.extend(0.0)));
+		TransformBundle::from_transform(Transform::from_translation(data.position.extend(0.0)));
 	let vertex_id = commands
 		.spawn((
 			Vertex,
@@ -183,7 +172,7 @@ fn spawn_vertex(
 		StateScoped(Screen::Playing),
 		LevelScoped,
 		ColorMesh2dBundle {
-			transform: Transform::from_translation(position.extend(layers::CYCLE_NODES)),
+			transform: Transform::from_translation(data.position.extend(layers::CYCLE_NODES)),
 			mesh: bevy::sprite::Mesh2dHandle(meshes.add(mesh)),
 			material: base_material,
 			..default()
@@ -208,7 +197,9 @@ fn spawn_vertex(
 						..default()
 					},
 					texture: image_handles[&ImageKey::Object(thing_type)].clone_weak(),
-					transform: Transform::from_translation(position.extend(layers::OBJECT_SPRITES)),
+					transform: Transform::from_translation(
+						data.position.extend(layers::OBJECT_SPRITES),
+					),
 					..Default::default()
 				},
 				AnimatedObject::default(),
@@ -239,7 +230,9 @@ fn spawn_vertex(
 						..default()
 					},
 					texture: image_handles[&ImageKey::Object(thing_type)].clone_weak(),
-					transform: Transform::from_translation(position.extend(layers::OBJECT_SPRITES)),
+					transform: Transform::from_translation(
+						data.position.extend(layers::OBJECT_SPRITES),
+					),
 					..Default::default()
 				},
 				AnimatedObject::default(),
@@ -283,7 +276,9 @@ fn spawn_vertex(
 						..default()
 					},
 					texture: image_handles[&ImageKey::Object(thing_type)].clone_weak(),
-					transform: Transform::from_translation(position.extend(layers::GLYPH_SPRITES)),
+					transform: Transform::from_translation(
+						data.position.extend(layers::GLYPH_SPRITES),
+					),
 					..Default::default()
 				},
 				Hoverable {
@@ -310,7 +305,9 @@ fn spawn_vertex(
 						..default()
 					},
 					texture: image_handles[&ImageKey::Object(thing_type)].clone_weak(),
-					transform: Transform::from_translation(position.extend(layers::GLYPH_SPRITES)),
+					transform: Transform::from_translation(
+						data.position.extend(layers::GLYPH_SPRITES),
+					),
 					..Default::default()
 				},
 				Hoverable {
@@ -342,12 +339,11 @@ fn spawn_cycle(
 	palette: &ThingPalette,
 	image_handles: &HandleMap<ImageKey>,
 	data: &CycleData,
-	placement: layout::CyclePlacement,
 	vertex_entities: &[Entity],
 ) -> Entity {
 	let mesh = primitives::Annulus::new(
-		placement.radius - RING_HALF_WIDTH,
-		placement.radius + RING_HALF_WIDTH,
+		data.placement.radius - RING_HALF_WIDTH,
+		data.placement.radius + RING_HALF_WIDTH,
 	)
 	.mesh()
 	.resolution(64)
@@ -355,7 +351,7 @@ fn spawn_cycle(
 
 	commands
 		.spawn((
-			data.cycle_turnability,
+			data.turnability,
 			StateScoped(Screen::Playing),
 			LevelScoped,
 			ComputedCycleTurnability(true),
@@ -365,10 +361,10 @@ fn spawn_cycle(
 					.map(|i| *vertex_entities.get(*i).unwrap())
 					.collect(),
 			),
-			CycleInterationRadius(placement.radius),
+			CycleInterationRadius(data.placement.radius),
 			CycleInteraction::default(),
 			TransformBundle::from_transform(Transform::from_translation(
-				placement.position.extend(0.0),
+				data.placement.position.extend(0.0),
 			)),
 			VisibilityBundle::default(),
 		))
@@ -380,8 +376,7 @@ fn spawn_cycle(
 						color: palette.cycle_ready,
 						..default()
 					},
-					texture: image_handles[&ImageKey::CycleCenter(data.cycle_turnability)]
-						.clone_weak(),
+					texture: image_handles[&ImageKey::CycleCenter(data.turnability)].clone_weak(),
 					transform: Transform::from_translation(
 						Vec2::ZERO.extend(layers::CYCLE_CENTER_SPRITES),
 					),
@@ -389,7 +384,7 @@ fn spawn_cycle(
 				},
 				JumpTurnAnimation::default(),
 				Hoverable {
-					hover_text: match data.cycle_turnability {
+					hover_text: match data.turnability {
 						CycleTurnability::Always => hover::CYCLE_AUTOMATIC,
 						CycleTurnability::WithPlayer => hover::CYCLE_MANUAL,
 						CycleTurnability::Never => hover::CYCLE_STILL,

--- a/src/game/spawn/level.rs
+++ b/src/game/spawn/level.rs
@@ -76,11 +76,9 @@ fn spawn_level(
 			.iter()
 			.map(|&(j, dir)| (cycle_ids[j], dir))
 			.collect::<Vec<_>>();
-		if !linked_cycles.is_empty() {
-			commands
-				.entity(cycle_id)
-				.insert(LinkedCycles(linked_cycles));
-		}
+		commands
+			.entity(cycle_id)
+			.insert(LinkedCycles(linked_cycles));
 	}
 
 	for link in &level.declared_links {

--- a/src/screen/level_select.rs
+++ b/src/screen/level_select.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use super::*;
 use crate::{
 	assets::{GlobalFont, LoadedLevelList},
-	game::level::LevelAsset,
+	game::level::LevelData,
 	ui::prelude::*,
 };
 
@@ -26,7 +26,7 @@ fn spawn_screen(
 	mut commands: Commands,
 	levels: Res<LoadedLevelList>,
 	font: Res<GlobalFont>,
-	level_assets: Res<Assets<LevelAsset>>,
+	level_assets: Res<Assets<LevelData>>,
 ) {
 	commands
 		.ui_root()

--- a/src/screen/playing.rs
+++ b/src/screen/playing.rs
@@ -4,7 +4,7 @@ use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 
 use crate::{
 	assets::{GlobalFont, LoadedLevelList},
-	game::{events::SpawnLevel, level::LevelAsset, prelude::*},
+	game::{events::SpawnLevel, level::LevelData, prelude::*},
 	send_event,
 	ui::prelude::*,
 	AppSet,
@@ -258,7 +258,7 @@ fn despawn_level_state_scoped(mut commands: Commands, query: Query<Entity, With<
 fn load_level(
 	mut commands: Commands,
 	level_list: Res<LoadedLevelList>,
-	level_assets: Res<Assets<LevelAsset>>,
+	level_assets: Res<Assets<LevelData>>,
 	playing_level: Res<State<PlayingLevel>>,
 	mut level_name_q: Query<&mut Text, With<LevelNameBox>>,
 ) {


### PR DESCRIPTION
This is a *preeeetty* big refactoring, so I put it here before recklessly merging. Please do suggest changes before or if we commit to this.

Here are the main changes that took place:
- Instead of a validator and a layout engine, there is now one component that assembles the level description. All validation is done eagerly as entities are inserted. Certain validations have been moved to where they actually matter (such as the condition that no two cycles share more than two vertices is now verified in the layout engine when it becomes a problem).
- The output of the parse function (the "level description" object) is now the whole level asset.
- Logical object colors have been temporarily removed. We should re-add them when we settle on a design for them.
- New batch of tests to catch any errors that might have been introduced.

Further points to consider:
- Errors are currently a bit awkward. If the level builder fails, its error data references objects by index, not by name as the parser recceives them. It would be a good idea to add an error translation layer for this.
- The level builder is currently doing a lot of things. We may want to split some of them off, e.g. put the level name and hint separately from the rest (yes, the very point of this refactoring was to merge two components into this builder, but *those* two should be one thing).