### PR TITLE
Allow loading of partial levels

### DIFF
--- a/src/game/components.rs
+++ b/src/game/components.rs
@@ -65,6 +65,7 @@ pub struct Cycle {
 pub struct CycleVertices(pub Vec<Entity>);
 
 /// A component holding a strong handle to the current level, making sure it stays alive and providing access to it.
+/// Is only present if the level is correct and logical systems can run on it.
 #[derive(Resource, Debug, Clone, Reflect)]
 pub struct LevelHandle(pub Handle<LevelData>);
 

--- a/src/game/level/backend/builder/test.rs
+++ b/src/game/level/backend/builder/test.rs
@@ -10,7 +10,14 @@ use crate::epilang::interpreter::{FunctionCallError, InterpreterError, LogicErro
 use std::f32::consts::PI;
 
 fn parse(level_file: &str) -> Result<LevelData, Error> {
-	super::parse_and_run(level_file, |_| {})
+	match super::parse_and_run(level_file, |_| {}) {
+		(None, None) => panic!("AAAAAA"),
+		(_, Some(err)) => Err(err),
+		(Some(level), None) => {
+			assert!(level.is_valid);
+			Ok(level)
+		}
+	}
 }
 
 macro_rules! assert_err_eq {

--- a/src/game/level/backend/builder/test.rs
+++ b/src/game/level/backend/builder/test.rs
@@ -11,12 +11,12 @@ use std::f32::consts::PI;
 
 fn parse(level_file: &str) -> Result<LevelData, Error> {
 	match super::parse_and_run(level_file, |_| {}) {
-		(None, None) => panic!("AAAAAA"),
-		(_, Some(err)) => Err(err),
-		(Some(level), None) => {
+		builder::ResultNonExclusive::Ok(level) => {
 			assert!(level.is_valid);
 			Ok(level)
 		}
+		builder::ResultNonExclusive::Partial(_, err) => Err(err),
+		builder::ResultNonExclusive::Err(err) => Err(err),
 	}
 }
 

--- a/src/game/level/builder/logic.rs
+++ b/src/game/level/builder/logic.rs
@@ -211,7 +211,7 @@ impl LevelBuilder {
 	}
 
 	/// Checks that the level data is complete and assembles it
-	pub fn build(mut self) -> (LevelData, Option<LevelBuilderError>) {
+	pub fn build(mut self) -> ResultNonExclusive<LevelData, LevelBuilderError> {
 		let mut is_valid = true;
 		let mut building_error = None;
 
@@ -246,7 +246,7 @@ impl LevelBuilder {
 			.into_iter()
 			.map(Self::build_vertex_data)
 			.collect();
-		(
+		ResultNonExclusive::from((
 			LevelData {
 				is_valid,
 				name: self
@@ -263,7 +263,7 @@ impl LevelBuilder {
 				execution_order,
 			},
 			building_error,
-		)
+		))
 	}
 
 	/// Computes and creates the GroupData objects

--- a/src/game/level/builder/logic.rs
+++ b/src/game/level/builder/logic.rs
@@ -215,23 +215,17 @@ impl LevelBuilder {
 		let mut is_valid = true;
 		let mut building_error = None;
 
-		fn set_if_none<T>(target: &mut Option<T>, value: T) {
-			if target.is_none() {
-				*target = Some(value);
-			}
-		}
-
 		let (groups, detectors, execution_order) =
 			self.compute_groups_and_detectors().unwrap_or_else(|err| {
 				is_valid = false;
-				set_if_none(&mut building_error, err);
+				building_error.get_or_insert(err);
 				(Vec::new(), Vec::new(), Vec::new())
 			});
 		let forbidden_group_pairs = if is_valid {
 			self.compute_forbidden_groups(&groups)
 				.unwrap_or_else(|err| {
 					is_valid = false;
-					set_if_none(&mut building_error, err);
+					building_error.get_or_insert(err);
 					Vec::new()
 				})
 		} else {
@@ -239,7 +233,7 @@ impl LevelBuilder {
 		};
 		self.validate_before_build().unwrap_or_else(|err| {
 			is_valid = false;
-			set_if_none(&mut building_error, err);
+			building_error.get_or_insert(err);
 		});
 		self.build_layout();
 		let cycles = self

--- a/src/game/level/builder/logic.rs
+++ b/src/game/level/builder/logic.rs
@@ -211,10 +211,36 @@ impl LevelBuilder {
 	}
 
 	/// Checks that the level data is complete and assembles it
-	pub fn build(mut self) -> Result<LevelData, LevelBuilderError> {
-		let (groups, detectors, execution_order) = self.compute_groups_and_detectors()?;
-		let forbidden_group_pairs = self.compute_forbidden_groups(&groups)?;
-		self.validate_before_build()?;
+	pub fn build(mut self) -> (LevelData, Option<LevelBuilderError>) {
+		let mut is_valid = true;
+		let mut building_error = None;
+
+		fn set_if_none<T>(target: &mut Option<T>, value: T) {
+			if target.is_none() {
+				*target = Some(value);
+			}
+		}
+
+		let (groups, detectors, execution_order) =
+			self.compute_groups_and_detectors().unwrap_or_else(|err| {
+				is_valid = false;
+				set_if_none(&mut building_error, err);
+				(Vec::new(), Vec::new(), Vec::new())
+			});
+		let forbidden_group_pairs = if is_valid {
+			self.compute_forbidden_groups(&groups)
+				.unwrap_or_else(|err| {
+					is_valid = false;
+					set_if_none(&mut building_error, err);
+					Vec::new()
+				})
+		} else {
+			Vec::new()
+		};
+		self.validate_before_build().unwrap_or_else(|err| {
+			is_valid = false;
+			set_if_none(&mut building_error, err);
+		});
 		self.build_layout();
 		let cycles = self
 			.cycles
@@ -226,20 +252,24 @@ impl LevelBuilder {
 			.into_iter()
 			.map(Self::build_vertex_data)
 			.collect();
-		Ok(LevelData {
-			name: self
-				.name
-				.unwrap_or_else(|| Self::PLACEHOLDER_LEVEL_NAME.to_owned()),
-			hint: self.hint,
-			vertices,
-			cycles,
-			groups,
-			detectors,
-			declared_links: self.declared_links,
-			declared_one_way_links: self.declared_one_way_cycle_links,
-			forbidden_group_pairs,
-			execution_order,
-		})
+		(
+			LevelData {
+				is_valid,
+				name: self
+					.name
+					.unwrap_or_else(|| Self::PLACEHOLDER_LEVEL_NAME.to_owned()),
+				hint: self.hint,
+				vertices,
+				cycles,
+				groups,
+				detectors,
+				declared_links: self.declared_links,
+				declared_one_way_links: self.declared_one_way_cycle_links,
+				forbidden_group_pairs,
+				execution_order,
+			},
+			building_error,
+		)
 	}
 
 	/// Computes and creates the GroupData objects
@@ -562,8 +592,6 @@ impl LevelBuilder {
 	}
 
 	/// Asserts that a vertex data object is complete and assembles it
-	/// ## Panics
-	/// Panics if the vertex is partially placed
 	fn build_vertex_data(intermediate: IntermediateVertexData) -> VertexData {
 		let position = match intermediate.position {
 			IntermediateVertexPosition::Fixed(pos) => pos,
@@ -571,7 +599,8 @@ impl LevelBuilder {
 			IntermediateVertexPosition::Free => Vec2::ZERO,
 			// Prevented by [`materialize_all_partial_vertex_placements`]
 			IntermediateVertexPosition::Partial(_) => {
-				panic!("Partially placed vertex in build phase, should have been materialized")
+				warn!("Partially placed vertex in build phase, should have been materialized");
+				Vec2::ONE
 			}
 		};
 		VertexData {
@@ -582,20 +611,26 @@ impl LevelBuilder {
 	}
 
 	/// Asserts that a cycle data object is complete and assembles it
-	/// ## Panics
-	/// Panics if the cycle has not been placed
 	fn build_cycle_data(intermediate: IntermediateCycleData) -> CycleData {
 		let placement = intermediate
-			.placement
-			.expect("Unplaced cycle in build phase, should have been detected earlier");
-		let center_sprite_position = intermediate.center_sprite_position.expect(
-			"Unplaced cycle center sprite in build phase, should have been materialized earlier",
-		);
+			.placement.unwrap_or_else(|| {
+				warn!("Unplaced cycle in build phase, should have been detected earlier, defaulting to some position");
+				CyclePlacement { position: Vec2::ZERO, shape: CycleShape::Circle(1.0) }
+			});
+		let center_sprite_position = intermediate.center_sprite_position.unwrap_or_else(|| {
+			warn!("Unplaced cycle center sprite in build phase, should have been materialized earlier, defaulting to None");
+			None
+		});
 		let center_sprite_appearence =
 			CycleCenterSpriteAppearence(center_sprite_position.map(|p| p - placement.position));
-		let IntermediateLinkStatus::Group(group, relative_direction) = intermediate.linked_cycle
-		else {
-			panic!("Cycle in build phase doesn't have a link pointer, should've been resolved in [`compute_groups_and_detectors`]");
+		let (group, relative_direction) = match intermediate.linked_cycle {
+			IntermediateLinkStatus::Group(group, relative_direction) => (group, relative_direction),
+			_ => {
+				warn!(
+					"Cycle built without a valid group assignment, defaulting to an invalid value"
+				);
+				(0, LinkedCycleDirection::Coincident)
+			}
 		};
 		CycleData {
 			placement,
@@ -625,7 +660,7 @@ impl LevelBuilder {
 		let mut relative_direction = LinkedCycleDirection::Coincident;
 		while let IntermediateLinkStatus::Cycle(lower, direction) = self.cycles[cycle].linked_cycle
 		{
-			// Todo: Optimise by shortening the path as we traverse it.
+			// TODO: Optimise by shortening the path as we traverse it.
 			cycle = lower;
 			relative_direction *= direction;
 		}

--- a/src/game/level/builder/mod.rs
+++ b/src/game/level/builder/mod.rs
@@ -192,3 +192,67 @@ impl<T> IntoIterator for OneTwo<T> {
 		}
 	}
 }
+
+/// Result type that allows both a value and an error.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ResultNonExclusive<T, E> {
+	Ok(T),
+	Partial(T, E),
+	Err(E),
+}
+
+#[allow(dead_code)]
+impl<T, E> ResultNonExclusive<T, E> {
+	pub fn value(self) -> Option<T> {
+		match self {
+			ResultNonExclusive::Ok(value) => Some(value),
+			ResultNonExclusive::Partial(value, _) => Some(value),
+			ResultNonExclusive::Err(_) => None,
+		}
+	}
+
+	pub fn error(self) -> Option<E> {
+		match self {
+			ResultNonExclusive::Ok(_) => None,
+			ResultNonExclusive::Partial(_, err) => Some(err),
+			ResultNonExclusive::Err(err) => Some(err),
+		}
+	}
+
+	pub fn into<A, B>(self) -> ResultNonExclusive<A, B>
+	where
+		A: From<T>,
+		B: From<E>,
+	{
+		match self {
+			ResultNonExclusive::Ok(value) => ResultNonExclusive::Ok(value.into()),
+			ResultNonExclusive::Partial(value, err) => {
+				ResultNonExclusive::Partial(value.into(), err.into())
+			}
+			ResultNonExclusive::Err(err) => ResultNonExclusive::Err(err.into()),
+		}
+	}
+
+	pub fn map_err<E2>(self, map: impl FnOnce(E) -> E2) -> ResultNonExclusive<T, E2> {
+		match self {
+			ResultNonExclusive::Ok(value) => ResultNonExclusive::Ok(value),
+			ResultNonExclusive::Partial(value, err) => ResultNonExclusive::Partial(value, map(err)),
+			ResultNonExclusive::Err(err) => ResultNonExclusive::Err(map(err)),
+		}
+	}
+}
+
+impl<T, E> From<(T, Option<E>)> for ResultNonExclusive<T, E> {
+	fn from(value: (T, Option<E>)) -> Self {
+		match value {
+			(value, None) => ResultNonExclusive::Ok(value),
+			(value, Some(err)) => ResultNonExclusive::Partial(value, err),
+		}
+	}
+}
+
+impl<T, E> From<E> for ResultNonExclusive<T, E> {
+	fn from(err: E) -> Self {
+		ResultNonExclusive::Err(err)
+	}
+}

--- a/src/game/level/mod.rs
+++ b/src/game/level/mod.rs
@@ -9,6 +9,8 @@ pub mod list_asset;
 /// Complete description of a level
 #[derive(Debug, Clone, Reflect, Asset)]
 pub struct LevelData {
+	/// Whether this level is correctly built
+	pub is_valid: bool,
 	/// Name of the level
 	pub name: String,
 	/// Hint or comment that relates to the level, if any

--- a/src/game/spawn.rs
+++ b/src/game/spawn.rs
@@ -236,13 +236,21 @@ fn spawn_primary_level_entities(
 		}
 
 		// Spawn cycle list
-		commands.insert_resource(CycleEntities(cycles));
-		commands.insert_resource(VertexEntities(vertices));
-		commands.insert_resource(LevelHandle(
-			levels
-				.get_strong_handle(level_handle.id())
-				.expect("I expect you to work."),
-		));
+		if level.is_valid {
+			commands.insert_resource(CycleEntities(cycles));
+			commands.insert_resource(VertexEntities(vertices));
+			commands.insert_resource(LevelHandle(
+				levels
+					.get_strong_handle(level_handle.id())
+					.expect("I expect you to work."),
+			));
+		} else {
+			// Ensure the [`LevelHandle`] is not around for an invalid level.
+			commands.remove_resource::<LevelHandle>();
+			// Just to be sure, remove these resources as well.
+			commands.remove_resource::<CycleEntities>();
+			commands.remove_resource::<VertexEntities>();
+		}
 	}
 }
 

--- a/src/game/test.rs
+++ b/src/game/test.rs
@@ -80,8 +80,10 @@ mod utils {
 
 	pub fn app_with_level(level: &str) -> App {
 		let mut app = setup_app();
-		let level =
-			parser::parse_and_run(level, |_| {}).expect("Level data should compile correctly!");
+		let level = parser::parse_and_run(level, |_| {})
+			.0
+			.expect("Level data should compile correctly!");
+		assert!(level.is_valid);
 
 		app.world_mut()
 			.run_system_once_with(level, load_level)

--- a/src/game/test.rs
+++ b/src/game/test.rs
@@ -81,7 +81,7 @@ mod utils {
 	pub fn app_with_level(level: &str) -> App {
 		let mut app = setup_app();
 		let level = parser::parse_and_run(level, |_| {})
-			.0
+			.value()
 			.expect("Level data should compile correctly!");
 		assert!(level.is_valid);
 

--- a/src/screen/mod.rs
+++ b/src/screen/mod.rs
@@ -65,6 +65,7 @@ pub enum Screen {
 	Title,
 	Credits,
 	LevelSelect,
+	/// The actual playing screen of the game.
 	Playing,
 }
 


### PR DESCRIPTION
# Goal
Allow the visualisation of partially loaded levels for debugging and development purposes.

Fixes #45 

# Changes
- Made the builder hopefully more robust
- Builder now may return LevelData in addition to errors.
- The level construction pipeline now uses weird types instead of results for error handling.
- Level spawning should be hopefully sufficiently robust against malformed LevelData
- LevelHandle resource is around only when the LevelData is valid.