### PR TITLE
Layout rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ log = { version = "0.4", features = [
     "release_max_level_warn",
 ] }
 rand =  { version = "0.8", features = ["small_rng"] }
+smallvec = "1.13.2" # Use same version as bevy does
 regex = "1.10.5"
 logos = "0.15.0"
 pomelo = "0.2.1"

--- a/assets/levels/2_sort.txt
+++ b/assets/levels/2_sort.txt
@@ -19,6 +19,7 @@ main = cycle(
 circle(main; 0 0 100);
 circle(cycle(y x); 120 0 40);
 circle(cycle(v = vertex(player()), flag()); 220 30 35);
-set_vertex_angle(v; 40);
+# x should be "above"
+hint_vertex(x; 0 100);
 
 cycle_color_labels(main; 'tb' 'in' 'arrow');

--- a/assets/levels/5_sync.txt
+++ b/assets/levels/5_sync.txt
@@ -13,3 +13,4 @@ link(spin side);
 circle(main; 0 0 100);
 circle(spin; 110 0 40);
 circle(side; 240 0 60);
+hint_vertex(g; 0, 100);

--- a/assets/levels/6_sync2.txt
+++ b/assets/levels/6_sync2.txt
@@ -12,3 +12,5 @@ link(main side);
 circle(main; 0 0 100);
 circle(spin; -110, 0 40);
 circle(side; 200 0 60);
+
+hint_vertex(a; 0, 100);

--- a/assets/levels/linked_sort.txt
+++ b/assets/levels/linked_sort.txt
@@ -23,6 +23,6 @@ circle(main; 0 0 100);
 circle(sideA; 110 20 40);
 circle(sideB; -110, 20 40);
 circle(player; 180, -60, 35);
-set_vertex_angle(v; 40);
+hint_vertex(v; 180, -60 + 35);
 
 cycle_color_labels(main; 'tb' 'in' 'arrow');

--- a/assets/levels/send.txt
+++ b/assets/levels/send.txt
@@ -16,3 +16,6 @@ circle(main; 0 0 100);
 circle(connect; 140 0 40);
 circle(side; 210.7, -70.7, 60);
 circle(spin; 50 120 50);
+
+# Decide between the two very close intersections arbitrarily
+hint_vertex(h; 0,0);

--- a/src/game/level/backend/builder/runtime.rs
+++ b/src/game/level/backend/builder/runtime.rs
@@ -286,7 +286,7 @@ impl LevelBuilder {
 			None
 		};
 		args.read_end()?;
-		self.place_cycle(cycle_id, Vec2::new(x, y), r, &[])?;
+		self.place_circle(cycle_id, Vec2::new(x, y), r)?;
 		if let Some(position) = center_position {
 			self.place_cycle_center(cycle_id, position)?;
 		}

--- a/src/game/level/backend/builder/runtime.rs
+++ b/src/game/level/backend/builder/runtime.rs
@@ -56,7 +56,7 @@ impl InterpreterBackend for LevelBuilder {
 			"circle" => self.call_circle(args),
 			"put_center" => self.call_put_center(args),
 			"put_vertex" => self.call_put_vertex(args),
-			"set_vertex_angle" => self.call_set_vertex_angle(args),
+			"hint_vertex" => self.call_hint_vertex(args),
 			"link" => self.call_link(false, args, warnings),
 			"oneway" => self.call_link(true, args, warnings),
 			"cycle_color_labels" => self.call_cycle_color_labels(args),
@@ -302,14 +302,6 @@ impl LevelBuilder {
 		Ok(ReturnValue::with_side_effect(CycleId(cycle_id).into()))
 	}
 
-	fn call_set_vertex_angle(&mut self, mut args: ArgumentStream<DomainValue>) -> CallResult {
-		let VertexId(vertex_id) = args.read_as()?;
-		args.read_separator()?;
-		let degrees: f32 = args.read_single_as()?;
-		self.place_vertex_at_angle(vertex_id, degrees * PI / 180.0)?;
-		Ok(ReturnValue::with_side_effect(VertexId(vertex_id).into()))
-	}
-
 	fn call_put_vertex(&mut self, mut args: ArgumentStream<DomainValue>) -> CallResult {
 		let VertexId(vertex_id) = args.read_as()?;
 		args.read_separator()?;
@@ -317,6 +309,16 @@ impl LevelBuilder {
 		let y = args.read_as()?;
 		args.read_end()?;
 		self.place_vertex(vertex_id, Vec2::new(x, y))?;
+		Ok(ReturnValue::with_side_effect(VertexId(vertex_id).into()))
+	}
+
+	fn call_hint_vertex(&mut self, mut args: ArgumentStream<DomainValue>) -> CallResult {
+		let VertexId(vertex_id) = args.read_as()?;
+		args.read_separator()?;
+		let x = args.read_as()?;
+		let y = args.read_as()?;
+		args.read_end()?;
+		self.add_vertex_hint(vertex_id, Vec2::new(x, y))?;
 		Ok(ReturnValue::with_side_effect(VertexId(vertex_id).into()))
 	}
 

--- a/src/game/level/builder/layout.rs
+++ b/src/game/level/builder/layout.rs
@@ -254,7 +254,7 @@ impl LevelBuilder {
 			points_on_cycle: Vec<Vec<usize>>,
 		}
 
-		#[derive(Clone)]
+		#[derive(Clone, Debug)]
 		struct CyclePoints {
 			first_undecided_vertex: Option<usize>,
 			first_decided_vertex: Option<usize>,
@@ -394,8 +394,9 @@ impl LevelBuilder {
 							LogicalVertexVariant::Single {
 								next_single: next_after_prev_single,
 							} => {
+								let previous_successor = *next_after_prev_single;
 								*next_after_prev_single = index;
-								*next_after_prev_single
+								previous_successor
 							}
 							LogicalVertexVariant::Pair { .. } => {
 								debug_assert!(false, "`prev_single` pointed to a Pair vertex");
@@ -506,6 +507,7 @@ impl LevelBuilder {
 			},
 		}
 
+		#[derive(Debug)]
 		struct PointData {
 			points: Vec<Vec2>,
 			vertices_interested_in_point: Vec<SmallVec<[usize; 1]>>,

--- a/src/game/level/builder/layout.rs
+++ b/src/game/level/builder/layout.rs
@@ -1288,7 +1288,7 @@ impl LevelBuilder {
 			match point_data.vertex_constraints[vertex_id] {
 				IntersectionPointSet::Single(point) => {
 					vertex_placement.position =
-						IntermediateVertexPosition::Fixed(point_data.points[point])
+						IntermediateVertexPosition::Fixed(point_data.points[point]);
 				}
 				IntersectionPointSet::Unconstrained => todo!(),
 				IntersectionPointSet::Cycle(_) => {}

--- a/src/game/level/builder/logic.rs
+++ b/src/game/level/builder/logic.rs
@@ -87,7 +87,7 @@ impl LevelBuilder {
 			.into_iter()
 			.map(|(detector, position)| (detector, i32::rem_euclid(position, n_vertices) as usize))
 			.collect::<Vec<_>>();
-		// If there are detecotrs but no vertices, this cycle is invalid.
+		// If there are detectors but no vertices, this cycle is invalid.
 		if vertex_indices.is_empty() && !detectors.is_empty() {
 			return Err(LevelBuilderError::DetectorOnEmptyCycle);
 		}
@@ -615,16 +615,7 @@ impl LevelBuilder {
 
 	/// Asserts that a vertex data object is complete and assembles it
 	fn build_vertex_data(intermediate: IntermediateVertexData) -> VertexData {
-		let position = match intermediate.position {
-			IntermediateVertexPosition::Fixed(pos) => pos,
-			// This is technically possible, since a vertex can belong to no cycle
-			IntermediateVertexPosition::Free => Vec2::ZERO,
-			// Prevented by [`materialize_all_partial_vertex_placements`]
-			IntermediateVertexPosition::Partial(_) => {
-				log::warn!("Partially placed vertex in build phase, should have been materialized");
-				Vec2::ONE
-			}
-		};
+		let position = intermediate.position.get_fixed().unwrap_or_default();
 		VertexData {
 			position,
 			object: intermediate.object,

--- a/src/game/level/builder/logic.rs
+++ b/src/game/level/builder/logic.rs
@@ -57,6 +57,7 @@ impl LevelBuilder {
 	pub fn add_vertex(&mut self) -> Result<usize, LevelBuilderError> {
 		self.vertices.push(IntermediateVertexData {
 			position: IntermediateVertexPosition::Free,
+			hint_position: None,
 			object: None,
 			glyph: None,
 			color_label_appearence: None,

--- a/src/game/level/builder/mod.rs
+++ b/src/game/level/builder/mod.rs
@@ -84,6 +84,8 @@ pub struct PartialVec2 {
 struct IntermediateVertexData {
 	/// Position of the vertex, if it has been placed yet
 	pub position: IntermediateVertexPosition,
+	/// Position to use as a hint when placing the vertex, if any
+	pub hint_position: Option<Vec2>,
 	/// Object that lies on the vertex, if any
 	pub object: Option<ObjectData>,
 	/// Glyph that lies on the vertex, if any
@@ -161,16 +163,6 @@ impl IntermediateVertexPosition {
 	}
 }
 
-/// Placement of a vertex that belongs to a placed cycle,
-/// but does not yet have a definite placement
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-struct PartiallyBoundVertexPosition {
-	/// Index of the cycle that owns the vertex
-	owner_cycle: usize,
-	/// Index of the vertex within the owner cycle's vertex list
-	index_in_owner: usize,
-}
-
 /// Placeholder appearence for a button color label that will be
 /// styled with regard to the cycle it is placed on
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -192,21 +184,6 @@ enum OneTwo<T> {
 	Two(T, T),
 }
 use OneTwo::*;
-
-impl<T> OneTwo<T> {
-	fn add_to_one(self, x: T) -> Result<Self, (T, T, T)> {
-		match self {
-			One(a) => Ok(Two(a, x)),
-			Two(a, b) => Err((a, b, x)),
-		}
-	}
-
-	fn first(self) -> T {
-		match self {
-			One(x) | Two(x, _) => x,
-		}
-	}
-}
 
 impl<T> IntoIterator for OneTwo<T> {
 	type Item = T;

--- a/src/game/level/builder/mod.rs
+++ b/src/game/level/builder/mod.rs
@@ -150,9 +150,6 @@ enum IntermediateVertexPosition {
 	Free,
 	/// The vertex has a fixed position
 	Fixed(Vec2),
-	/// Exactly one cycle that owns the vertex has been placed
-	/// and the vertex may still be moved along it
-	Partial(PartiallyBoundVertexPosition),
 }
 
 impl IntermediateVertexPosition {
@@ -267,6 +264,20 @@ impl<T, E> ResultNonExclusive<T, E> {
 			ResultNonExclusive::Ok(value) => ResultNonExclusive::Ok(value),
 			ResultNonExclusive::Partial(value, err) => ResultNonExclusive::Partial(value, map(err)),
 			ResultNonExclusive::Err(err) => ResultNonExclusive::Err(map(err)),
+		}
+	}
+}
+
+#[allow(dead_code)]
+impl<T, E> ResultNonExclusive<T, E>
+where
+	E: std::fmt::Debug,
+{
+	pub fn unwrap_ok(self) -> T {
+		match self {
+			ResultNonExclusive::Ok(value) => value,
+			ResultNonExclusive::Partial(_value, err) => panic!("Unwrapped an Err: {err:?}"),
+			ResultNonExclusive::Err(err) => panic!("Unwrapped an Err: {err:?}"),
 		}
 	}
 }

--- a/src/game/level/mod.rs
+++ b/src/game/level/mod.rs
@@ -5,6 +5,8 @@ pub mod backend;
 pub mod builder;
 pub mod list;
 pub mod list_asset;
+#[cfg(test)]
+mod test;
 
 /// Complete description of a level
 #[derive(Debug, Clone, Reflect, Asset)]

--- a/src/game/level/test.rs
+++ b/src/game/level/test.rs
@@ -1,0 +1,112 @@
+use super::{
+	backend::builder::{parse_and_run, Error},
+	builder::ResultNonExclusive,
+	LevelData,
+};
+
+fn load(level: &str) -> ResultNonExclusive<LevelData, Error> {
+	parse_and_run(level, |w| println!("Warning: {}", w))
+}
+
+mod layout_tests {
+	use bevy::math::Vec2;
+	use itertools::Itertools;
+
+	use super::load;
+
+	#[test]
+	fn basic_metatest() {
+		load(r"").unwrap_ok();
+	}
+
+	#[test]
+	fn basic_unicycle() {
+		load(r"circle(cycle(_ _ _ _ _); 3, 5, 20);").unwrap_ok();
+	}
+
+	#[test]
+	fn basic_dicycles_single() {
+		load(
+			r"
+		v = vertex();
+		circle(cycle(v _ _ _ _); -10, 0, 10);
+		circle(cycle(v _ _ _ _); +10, 0, 10);
+		",
+		)
+		.unwrap_ok();
+
+		/* TODO
+		load(r"
+		v = vertex();
+		circle(cycle(v _); -7, 0, 10);
+		circle(cycle(v); +7, 0, 10);
+		").unwrap_ok();
+		*/
+
+		load(
+			r"
+		v = vertex();
+		circle(cycle(v _ _ _ _); 0, 0, 10);
+		circle(cycle(v _ _ _ _); 0, 0, 10);
+		",
+		)
+		.unwrap_ok();
+	}
+
+	#[test]
+	fn tricycle_interleaved() {
+		load(
+			r"
+r = 1;
+sep = 1.3;
+
+bri = vertex();
+rgi = vertex();
+bgi = vertex();
+bro = vertex();
+rgo = vertex();
+bgo = vertex();
+circle(cycle('manual'; _ _ _ _ bgo bri bgi bro); -sep / 2, 0, r);
+circle(cycle('manual'; _ _ _ _ bro rgi bri rgo); 0, -sep / 2 * sqrt(3), r);
+circle(cycle('manual'; _ _ _ _ rgo bgi rgi bgo); sep / 2, 0, r);
+",
+		)
+		.unwrap_ok();
+	}
+
+	fn get_flower(
+		flower_id: &str,
+		n_petals: usize,
+		n_extra_vertices: usize,
+		radius: f32,
+		position: Vec2,
+	) -> String {
+		let mut level = String::new();
+		for i in 0..n_petals {
+			level.push_str(&format!("v_{flower_id}_{i} = vertex();\n"));
+		}
+		level.push_str(&format!("center_{flower_id} = vertex();\n"));
+		level.push_str(&format!("radius_{flower_id} = {radius};\n"));
+		level.push_str(&format!("pos_x_{flower_id} = {};\n", position.x));
+		level.push_str(&format!("pos_y_{flower_id} = {};\n", position.y));
+		let additional = (0..n_extra_vertices).map(|_| "_").join(" ");
+		for i in 0..n_petals {
+			let j = (i + 1) % n_petals;
+			level.push_str(&format!("circle(cycle(v_{flower_id}_{j} center_{flower_id} v_{flower_id}_{i} {additional}); pos_x_{flower_id} + radius_{flower_id} * cos(-2 * pi * {i} / {n_petals}), pos_y_{flower_id} + radius_{flower_id} * sin(-2 * pi * {i} / {n_petals}), radius_{flower_id});\n"));
+		}
+		level
+	}
+
+	#[test]
+	fn flower() {
+		let flowers: Vec<String> = (3..8)
+			.map(|n_petals| {
+				get_flower(&format!("flower_{n_petals}"), n_petals, 3, 10.0, Vec2::ZERO)
+			})
+			.collect();
+		for flower in flowers.iter() {
+			load(flower).unwrap_ok();
+		}
+		load(&flowers.iter().join("")).unwrap_ok();
+	}
+}

--- a/src/game/level/test.rs
+++ b/src/game/level/test.rs
@@ -35,13 +35,16 @@ mod layout_tests {
 		)
 		.unwrap_ok();
 
-		/* TODO
-		load(r"
+		// TODO: Add test asserting this hint to be necessary
+		load(
+			r"
 		v = vertex();
 		circle(cycle(v _); -7, 0, 10);
 		circle(cycle(v); +7, 0, 10);
-		").unwrap_ok();
-		*/
+		hint_vertex(v; 0, 1);
+		",
+		)
+		.unwrap_ok();
 
 		load(
 			r"
@@ -51,6 +54,141 @@ mod layout_tests {
 		",
 		)
 		.unwrap_ok();
+	}
+
+	#[test]
+	fn basic_dicycles_double() {
+		// TODO: This should fail with an Err
+		// load(
+		// 	r"
+		// a = vertex();
+		// b = vertex();
+		// circle(cycle(a b _ _ _ _); -10, 0, 10);
+		// circle(cycle(b a _ _ _ _); +10, 0, 10);
+		// ",
+		// )
+
+		load(
+			r"
+		a = vertex();
+		b = vertex();
+		circle(cycle(a b _ _ _ _); -7, 0, 10);
+		circle(cycle(b a _ _ _ _); +7, 0, 10);
+		hint_vertex(a; 0, 2);
+		",
+		)
+		.unwrap_ok();
+
+		load(
+			r"
+		a = vertex();
+		b = vertex();
+		circle(cycle(a b _ _ _ _); -7, 0, 10);
+		circle(cycle(b a _ _ _ _); +7, 0, 10);
+		hint_vertex(b; 0, -2);
+		",
+		)
+		.unwrap_ok();
+
+		// TODO: Check that `a` was actually placed near `5,5`
+		load(
+			r"
+		a = vertex();
+		b = vertex();
+		circle(cycle(a b _ _ _); 0, 0, 10);
+		circle(cycle(a _ b _ _); 0, 0, 10);
+		hint_vertex(a; 5, 5);
+		",
+		)
+		.unwrap_ok();
+	}
+
+	#[test]
+	fn indirect_hints() {
+		load(
+			r"
+		a = vertex();
+		b = vertex();
+		rando_vertex = vertex();
+		circle(cycle(a b _ _ _ _); -7, 0, 10);
+		circle(cycle(b a _ _ rando_vertex _); +7, 0, 10);
+		# This hint is enough to decide the ambiguity
+		hint_vertex(rando_vertex; 0, +7);
+		",
+		)
+		.unwrap_ok();
+	}
+
+	#[test]
+	fn road_rage() {
+		// This level can be decided with no hints
+		load(
+			r"
+name = 'Car';
+hint = 'Fun fact: Originally this level was thought to be impossible!';
+
+box = box('lr');
+
+a = vertex(box);
+b = vertex(box);
+c = vertex(box);
+d = vertex(box);
+e = vertex(box);
+f = vertex(button() player());
+g = vertex();
+h = vertex(box button());
+i = vertex();
+j = vertex(box flag());
+k = vertex();
+l = vertex(button());
+m = vertex(button());
+n = vertex(button());
+o = vertex(button());
+p = vertex(button());
+
+circle(cycle('manual'; a b h m l f); 0 0 1);
+circle(cycle('manual'; i n m g b c); 1 0 1);
+circle(cycle('manual'; j o n h c d); 2 0 1);
+circle(cycle('manual'; k p o i d e); 3 0 1);",
+		)
+		.unwrap_ok();
+	}
+
+	#[test]
+	fn olympic() {
+		// A chain of cycles can also be automatically resolved
+		load(
+			r"
+name = 'Olympic';
+hint = 'Tip: In levels with a single player and manual cycles, it''s helpful to think about the player''s routes through the crossings.';
+
+box = box('desc_neg');
+
+dx = 4;
+dy = 3;
+r = 3;
+
+a = vertex(player() flag());
+b = vertex();
+c = vertex();
+d = vertex();
+e = vertex();
+f = vertex();
+g = vertex();
+h = vertex();
+i = vertex();
+circle(cycle('manual'; a box b c box _);          -2 * dx, dy, r);
+circle(cycle('manual'; _ _ c b d e);                  -dx,  0, r);
+circle(cycle('manual'; _ _ f g e d);                    0, dy, r);
+circle(cycle('manual'; _ _ g f h i);                   dx,  0, r);
+circle(cycle('manual'; _ button() button() _ i h); 2 * dx, dy, r);
+",
+		).unwrap_ok();
+	}
+
+	#[test]
+	fn olympic_polymorphic() {
+		// TODO: Stress test the pair-pair resolver
 	}
 
 	#[test]
@@ -69,6 +207,11 @@ bgo = vertex();
 circle(cycle('manual'; _ _ _ _ bgo bri bgi bro); -sep / 2, 0, r);
 circle(cycle('manual'; _ _ _ _ bro rgi bri rgo); 0, -sep / 2 * sqrt(3), r);
 circle(cycle('manual'; _ _ _ _ rgo bgi rgi bgo); sep / 2, 0, r);
+
+# Hint that the central vertices go near the center
+hint_vertex(bri; 0, 0);
+hint_vertex(rgi; 0, 0);
+hint_vertex(bgi; 0, 0);
 ",
 		)
 		.unwrap_ok();

--- a/src/game/test.rs
+++ b/src/game/test.rs
@@ -907,6 +907,8 @@ blue = cycle(_ button(0) _ bgo bri bgi bro);
 red = cycle(_ button(1) _ bro rgi bri rgo);
 green = cycle(_ button(2) _ rgo bgi rgi bgo);
 
+hint_vertex(bgi; 0,0);
+
 circle(blue; -87, 50 130);
 circle(red; 0, -100, 130);
 circle(green; 87 50 130);
@@ -1033,6 +1035,7 @@ fn stress_test_random_levels() {
 		include_str!("../../assets/levels/linked_sort.txt"),
 	];
 	for level in levels {
+		println!("{level}");
 		let mut app = app_with_level(level);
 		move_fuzz(&mut app, 4096, 1337133713371337);
 	}


### PR DESCRIPTION
# Objective
Make the layouter stop making me mad!
Now it can lay out stuff like olympics without fail, tricycle without arcane cycle/vertex-order weaving and also lay out some situations that I wouldn't've expected even possible.

## Outstanding issues:
1) There's no proper error handling paths for unsolvable levels
2) The layout engine lost its ability to make a guess in a situation where it doesn't matter, this makes it somewhat fragile, for example when there is actually a surprise 2-intersection instead of a 1-intersection.
3) More tests are desired (especially negative tests which look for intentional failures).

Contributes to #20 and indirectly contributes to making more levels. (Because I got stuck on layout issues every time!)